### PR TITLE
[BE/FE] Send and receive text functionality

### DIFF
--- a/yapper-be/rooms.js
+++ b/yapper-be/rooms.js
@@ -11,7 +11,7 @@ let rooms = {};
 //////////////////////////////
 
 let users = {};
-// structure of rooms ////////
+// structure of users ////////
 // {
 //     userId:{
 //         room: {
@@ -76,9 +76,9 @@ const disconnectUser = (userId) => {
     // if someone reloads the page or clicks back button then the socket.id will change
     if (users[userId] !== undefined) {
         let room = Object.keys(users[userId])[0];
-
+        let userDetails = {...rooms[room][userId], room, userId}
         removeUser(room, userId);
-        return room;
+        return userDetails;
     }
     return null;
 }
@@ -95,7 +95,8 @@ const getUsers = (room) => {
 }
 
 const getUserDetail = (room, userId) => {
-    return rooms[room][userId];
+    // sending userId (socket.id) might be a security threat. Will have to verify
+    return {...rooms[room][userId], userId};
 }
 
 export { addUser, removeUser, getUsers, disconnectUser, banUser, getUserDetail };

--- a/yapper-fe/src/Components/ChatBubble/ChatBubble.js
+++ b/yapper-fe/src/Components/ChatBubble/ChatBubble.js
@@ -16,10 +16,6 @@ import { useLocation, useNavigate } from 'react-router-dom';
 export function ChatBubbleOthers(props) {
     const socket = useContext(SocketContext);
 
-    useEffect(() => {
-        console.log(props);
-    }, []);
-
     return (
         <div className='chatBubbleParent'>
             <div className='chatBubbleAvatar'></div>
@@ -33,10 +29,6 @@ export function ChatBubbleOthers(props) {
 export function ChatBubbleSelf(props) {
     const socket = useContext(SocketContext);
 
-    useEffect(() => {
-        console.log(props);
-    }, []);
-
     return (
         <div className='chatBubbleParent' style={{ marginLeft: "auto" }}>
             <div className='chatBubbleTxtSelf'>
@@ -48,11 +40,17 @@ export function ChatBubbleSelf(props) {
 
 export function ChatBroadcast(props) {
     const socket = useContext(SocketContext);
+    const EnterMsgComp = () =>
+        <><strong>{props.userName}</strong> has <strong style={{ color: "#2ab296" }}>entered</strong> room: <strong>{props.room}</strong></>
+
+    const LeftMsgComp = () =>
+        <><strong>{props.userName}</strong> has <strong style={{ color: "rgb(215 91 91)" }}>left</strong> room: <strong>{props.room}</strong></>
 
     return (
         <div className='chatBubbleParent chatBroadcastParent'>
             <div className='chatBroadcastTxt'>
-                <strong style={{color: "#2ab296"}}>{props.userName}</strong>{props.message}<strong>{props.room}</strong>
+                {props.type === "new" && <EnterMsgComp />}
+                {props.type === "left" && <LeftMsgComp />}
             </div>
         </div>
     );

--- a/yapper-fe/src/Components/Dashboard/Dashboard.js
+++ b/yapper-fe/src/Components/Dashboard/Dashboard.js
@@ -18,10 +18,6 @@ import ChatInterface from "../ChatInterface/ChatInterface";
 export default function Dashboard(props) {
     const socket = useContext(SocketContext);
 
-    useEffect(() => {
-        console.log(props);
-    }, []);
-
     return (
         <div className='dashboardParent'>
             <div className='leftDiv'>

--- a/yapper-fe/src/Components/Home/Home.js
+++ b/yapper-fe/src/Components/Home/Home.js
@@ -30,13 +30,6 @@ function Home() {
     const socket = useContext(SocketContext);
     const navigate = useNavigate();
 
-    // will listen to server to get all users from the room when new user is added
-    useEffect(() => {
-        socket.on("users", users => {
-            console.log(users)
-        })
-    }, []);
-
     let create_room = () => {
         let room = Math.random().toString(20).substring(2, 7);
         setRoomID(room);
@@ -51,7 +44,6 @@ function Home() {
     }
 
     let join_room = () => {
-        console.log('join');
         setJoinRoom(true);
         setRoomID('');
     }
@@ -67,6 +59,15 @@ function Home() {
     let handleUserName = (e) => {
         (!e.target.value.replace(/\s/g, '').length) ? setHomeBtnDisable(true) : setHomeBtnDisable(false);
         setuserName(e.target.value);
+    }
+
+    const onRoomJoin = () => {
+    
+        socket.emit("enter room", { userName: userName, room: roomID, avatarIndex: selectedAvatarIndex }, err => {
+            console.log(err);
+        });
+
+        setloggedIn(true);
     }
 
     return (
@@ -110,7 +111,7 @@ function Home() {
                             onChange={handleRoomID} />
                         <div className='join_btn_grp'>
                             <button className="cancel_btn" onClick={() => { setJoinRoom(false); setJoinBtnDisable(true) }}><Clear /></button>
-                            <button className="next_btn" onClick={() => console.log("joined clicked")} disabled={isJoinBtnDisabled}><Send /></button>
+                            <button className="next_btn" onClick={onRoomJoin} disabled={isJoinBtnDisabled}><Send /></button>
                         </div>
                     </div>
                 }


### PR DESCRIPTION
Added first version of message send/receive feature:

- Handled following cases from **frontend**:
  - Message sending by current user
  - Message received from other users
  - New user entering the room
  - User leaving the room
  - Custom chat bubbles added for notification related to user joining/leaving the room
  - `txtList` state created to handle all user related data inside `ChatInterface` component
  - Naive room join logic added
- Added emitters in **backend**:
  - `new user`
  - `send text`
  - `receive text`
- Propagated all user details from `disconnect` emitter in backend
- Added `userId` data to `getUserDetail` method from `rooms.js`

> Room join functionality should mature going forward. Further emitters or states might be required to track all users in a room.